### PR TITLE
Add the option to set PROJECT_HOME and VIRTUALENVWRAPPER_PYTHON environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,15 @@ Role Variables
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-`virtualenvwrapper_version` per default set to `4.3.1`
+* `virtualenvwrapper_version = 4.3.1` - The version of virtualenvwrapper that will be installed.
 
-The version of virtualenvwrapper that will be installed.
+* `virtualenvwrapper_shell_rc_file = {{ ansible_env['HOME'] }}/.{{ ansible_env['SHELL'] | replace('/bin/','') }}rc` - The shell's configuration file for which virtualenvwrapper variables will be set.
 
-`virtualenvwrapper_shell_rc_file` per default set to
-`{{ ansible_env['HOME'] }}/.{{ ansible_env['SHELL'] | replace('/bin/','') }}rc`
+* `virtualenvwrapper_venvs_home = {{ ansible_env['HOME'] }}/.virtualenvs` - The path to place your virtual environements (sets WORKON_HOME env variable).
 
-The shell's configuration file for which virtualenvwrapper variables will be set.
+* `virtualenvwrapper_venvs_python` (No default) - Sets VIRTUALENVWRAPPER_PYTHON with a path of your choice
 
-`virtualenvwrapper_venvs_home` per default set to `{{ ansible_env['HOME'] }}/.virtualenvs`
-
-The path to place your virtual environements (sets WORKON_HOME env variable).
+* `virtualenvwrapper_venvs_project` (No default) - Sets PROJECT_HOME with a path of your choice
 
 Dependencies
 ------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,32 @@
     - virtualenvwrapper
     - virtualenvwrapper_configuration
 
+- name: set project home (if variable is set)
+  lineinfile: >
+    dest={{ virtualenvwrapper_shell_rc_file }}
+    regexp='export PROJECT_HOME'
+    line='export PROJECT_HOME={{ virtualenvwrapper_venvs_project }}'
+    state=present
+    backup=yes
+    create=yes
+  when: virtualenvwrapper_venvs_project is defined
+  tags:
+    - virtualenvwrapper
+    - virtualenvwrapper_configuration
+
+- name: set virtualenvwrapper python path (if variable is set)
+  lineinfile: >
+    dest={{ virtualenvwrapper_shell_rc_file }}
+    regexp='export VIRTUALENVWRAPPER_PYTHON'
+    line='export VIRTUALENVWRAPPER_PYTHON={{ virtualenvwrapper_venvs_python }}'
+    state=present
+    backup=yes
+    create=yes
+  when: virtualenvwrapper_venvs_python is defined
+  tags:
+    - virtualenvwrapper
+    - virtualenvwrapper_configuration
+
 - name: load virtualenvwrapper script
   lineinfile: >
     dest={{ virtualenvwrapper_shell_rc_file }}


### PR DESCRIPTION
Those settings helped me provision multiple systems with more ease (I also documented those vars on the README file):

Settings are added to path set with
`virtualenvwrapper_shell_rc_file` if the variables are set:
1. `virtualenvwrapper`_venvs_project - to set a PROJECT_HOME environment
   variable
2. `virtualenvwrapper_venvs_python` - to set VIRTUALENVWRAPPER_PYTHON with
   a python path other then the default one
